### PR TITLE
translate: transitions-with-the-key-attribute, fix: translate errors in /guide/built-ins

### DIFF
--- a/src/guide/built-ins/keep-alive.md
+++ b/src/guide/built-ins/keep-alive.md
@@ -141,4 +141,4 @@ export default {
 
 **Связанные**
 
-- [`<KeepAlive>` API reference](/api/built-in-components#keepalive)
+- [Справочник API — `<KeepAlive>`](/api/built-in-components#keepalive)

--- a/src/guide/built-ins/suspense.md
+++ b/src/guide/built-ins/suspense.md
@@ -135,6 +135,6 @@ const posts = await res.json()
 
 ---
 
-**Related**
+**Связанное**
 
-- [`<Suspense>` API reference](/api/built-in-components#suspense)
+- [Справочник API — `<Suspense>`](/api/built-in-components#suspense)

--- a/src/guide/built-ins/transition-group.md
+++ b/src/guide/built-ins/transition-group.md
@@ -132,4 +132,4 @@ function onEnter(el, done) {
 
 **Связанные**
 
-- [`<TransitionGroup>` API reference](/api/built-in-components#transitiongroup)
+- [Справочник API — `<TransitionGroup>`](/api/built-in-components#transitiongroup)

--- a/src/guide/built-ins/transition.md
+++ b/src/guide/built-ins/transition.md
@@ -583,11 +583,11 @@ export default {
 
 Также можно применять различное поведение в переходах JavaScript-хуков в зависимости от текущего состояния компонента. Наконец, окончательный способ создания динамических переходов - это [многократно используемые компоненты переходов](#reusable-transitions), которые принимают входные параметры для изменения характера используемого перехода (переходов). Это может показаться банальным, но на самом деле единственное ограничение - это ваше воображение.
 
-## Transitions with the Key Attribute {#transitions-with-the-key-attribute}
+## Переходы с атрибутом `key` {#transitions-with-the-key-attribute}
 
-Sometimes you need to force the re-render of a DOM element in order for a transition to occur.
+Иногда вам нужно принудительно выполнить повторный рендеринг элемента DOM, чтобы произошел переход.
 
-Take this counter component for example:
+Возьмем, к примеру, этот компонент счетчика:
 
 <div class="composition-api">
 
@@ -638,16 +638,16 @@ export default {
 
 </div>
 
-If we had excluded the `key` attribute, only the text node would be updated and thus no transition would occur. However, with the `key` attribute in place, Vue knows to create a new `span` element whenever `count` changes and thus the `Transition` component has 2 different elements to transition between.
+Если бы мы исключили атрибут `key`, обновлялся бы только текстовый узел, и, следовательно, переход не происходил бы. Однако, при наличии атрибута `key`, Vue знает, что нужно создавать новый элемент `span` всякий раз, когда изменяется `count`, таким образом, у компонента `Transition` есть 2 разных элемента для перехода между ними.
 
 <div class="composition-api">
 
-[Try it in the Playground](https://play.vuejs.org/#eNp9UsFu2zAM/RVCl6Zo4nhYd/GcAtvQQ3fYhq1HXTSFydTKkiDJbjLD/z5KMrKgLXoTHx/5+CiO7JNz1dAja1gbpFcuQsDYuxtuVOesjzCCxx1MsPO2gwuiXnzkhhtpTYggbW8ibBJlUV/mBJXfmYh+EHqxuITNDYzcQGFWBPZ4dUXEaQnv6jrXtOuiTJoUROycFhEpAmi3agCpRQgbzp68cA49ZyV174UJKiprckxIcMJA84hHImc9oo7jPOQ0kQ4RSvH6WXW7JiV6teszfQpDPGqEIK3DLSGpQbazsyaugvqLDVx77JIhbqp5wsxwtrRvPFI7NWDhEGtYYVrQSsgELzOiUQw4I2Vh8TRgA9YJqeIR6upDABQh9TpTAPE7WN3HlxLp084Foi3N54YN1KWEVpOMkkO2ZJHsmp3aVw/BGjqMXJE22jml0X93STRw1pReKSe0tk9fMxZ9nzwVXP5B+fgK/hAOCePsh8dAt4KcnXJR+D3S16X07a9veKD3KdnZba+J/UbyJ+Zl0IyF9rk3Wxr7jJenvcvnrcz+PtweItKuZ1Np0MScMp8zOvkvb1j/P+776jrX0UbZ9A+fYSTP)
+[Попробовать в песочнице](https://play.vuejs.org/#eNp9UsFu2zAM/RVCl6Zo4nhYd/GcAtvQQ3fYhq1HXTSFydTKkiDJbjLD/z5KMrKgLXoTHx/5+CiO7JNz1dAja1gbpFcuQsDYuxtuVOesjzCCxx1MsPO2gwuiXnzkhhtpTYggbW8ibBJlUV/mBJXfmYh+EHqxuITNDYzcQGFWBPZ4dUXEaQnv6jrXtOuiTJoUROycFhEpAmi3agCpRQgbzp68cA49ZyV174UJKiprckxIcMJA84hHImc9oo7jPOQ0kQ4RSvH6WXW7JiV6teszfQpDPGqEIK3DLSGpQbazsyaugvqLDVx77JIhbqp5wsxwtrRvPFI7NWDhEGtYYVrQSsgELzOiUQw4I2Vh8TRgA9YJqeIR6upDABQh9TpTAPE7WN3HlxLp084Foi3N54YN1KWEVpOMkkO2ZJHsmp3aVw/BGjqMXJE22jml0X93STRw1pReKSe0tk9fMxZ9nzwVXP5B+fgK/hAOCePsh8dAt4KcnXJR+D3S16X07a9veKD3KdnZba+J/UbyJ+Zl0IyF9rk3Wxr7jJenvcvnrcz+PtweItKuZ1Np0MScMp8zOvkvb1j/P+776jrX0UbZ9A+fYSTP)
 
 </div>
 <div class="options-api">
 
-[Try it in the Playground](https://play.vuejs.org/#eNp9U8tu2zAQ/JUFTwkSyw6aXlQ7QB85pIe2aHPUhZHWDhOKJMiVYtfwv3dJSpbbBgEMWJydndkdUXvx0bmi71CUYhlqrxzdVAa3znqCBtey0wT7ygA0kuTZeX4G8EidN+MJoLadoRKuLkdAGULfS12C6bSGDB/i3yFx2tiAzaRIjyoUYxesICDdDaczZq1uJrNETY4XFx8G5Uu4WiwW55PBA66txy8YyNvdZFNrlP4o/Jdpbq4M/5bzYxZ8IGydloR8Alg2qmcVGcKqEi9eOoe+EqnExXsvTVCkrBkQxoKTBspn3HFDmprp+32ODA4H9mLCKDD/R2E5Zz9+Ws5PpuBjoJ1GCLV12DASJdKGa2toFtRvLOHaY8vx8DrFMGdiOJvlS48sp3rMHGb1M4xRzGQdYU6REY6rxwHJGdJxwBKsk7WiHSyK9wFQhqh14gDyIVjd0f8Wa2/bUwOyWXwQLGGRWzicuChvKC4F8bpmrTbFU7CGL2zqiJm2Tmn03100DZUox5ddCam1ffmaMPJd3Cnj9SPWz6/gT2EbsUr88Bj4VmAljjWSfoP88mL59tc33PLzsdjaptPMfqP4E1MYPGOmfepMw2Of8NK0d238+JTZ3IfbLSFnPSwVB53udyX4q/38xurTuO+K6/Fqi8MffqhR/A==)
+[Попробовать в песочнице](https://play.vuejs.org/#eNp9U8tu2zAQ/JUFTwkSyw6aXlQ7QB85pIe2aHPUhZHWDhOKJMiVYtfwv3dJSpbbBgEMWJydndkdUXvx0bmi71CUYhlqrxzdVAa3znqCBtey0wT7ygA0kuTZeX4G8EidN+MJoLadoRKuLkdAGULfS12C6bSGDB/i3yFx2tiAzaRIjyoUYxesICDdDaczZq1uJrNETY4XFx8G5Uu4WiwW55PBA66txy8YyNvdZFNrlP4o/Jdpbq4M/5bzYxZ8IGydloR8Alg2qmcVGcKqEi9eOoe+EqnExXsvTVCkrBkQxoKTBspn3HFDmprp+32ODA4H9mLCKDD/R2E5Zz9+Ws5PpuBjoJ1GCLV12DASJdKGa2toFtRvLOHaY8vx8DrFMGdiOJvlS48sp3rMHGb1M4xRzGQdYU6REY6rxwHJGdJxwBKsk7WiHSyK9wFQhqh14gDyIVjd0f8Wa2/bUwOyWXwQLGGRWzicuChvKC4F8bpmrTbFU7CGL2zqiJm2Tmn03100DZUox5ddCam1ffmaMPJd3Cnj9SPWz6/gT2EbsUr88Bj4VmAljjWSfoP88mL59tc33PLzsdjaptPMfqP4E1MYPGOmfepMw2Of8NK0d238+JTZ3IfbLSFnPSwVB53udyX4q/38xurTuO+K6/Fqi8MffqhR/A==)
 
 </div>
 
@@ -655,4 +655,4 @@ If we had excluded the `key` attribute, only the text node would be updated and 
 
 **Связанное**
 
-- [`<Transition>` Справочник API](/api/built-in-components#transition)
+- [Справочник API — `<Transition>`](/api/built-in-components#transition)


### PR DESCRIPTION
## Description of Problem

* Был недопереведён перевод блока transitions-with-the-key-attribute, 
* Недопереведены участки ссылок

## Proposed Solution

* Добавлен перевод блока transitions-with-the-key-attribute
* Переведены участки ссылок с учетом перевода в блоке Teleport
