### PR TITLE
fix: change color names in English

### DIFF
--- a/src/examples/src/attribute-bindings/App/composition.js
+++ b/src/examples/src/attribute-bindings/App/composition.js
@@ -4,14 +4,14 @@ export default {
   setup() {
     const message = ref('Привет Мир!')
     const isRed = ref(true)
-    const color = ref('зеленый')
+    const color = ref('green')
 
     function toggleRed() {
       isRed.value = !isRed.value
     }
 
     function toggleColor() {
-      color.value = color.value === 'зеленый' ? 'синий' : 'зеленый'
+      color.value = color.value === 'green' ? 'blue' : 'green'
     }
 
     return {


### PR DESCRIPTION
На странице с примрами в разделе  Attribute bindings поменял название цвета текста на английский, потому что с русским написанием цвет параграфа не менялся

