### PR TITLE
fix: variables in options-api

### DIFF
--- a/src/examples/src/attribute-bindings/App/options.js
+++ b/src/examples/src/attribute-bindings/App/options.js
@@ -3,7 +3,7 @@ export default {
     return {
       message: 'Привет Мир!',
       isRed: true,
-      color: 'зеленый'
+      color: 'green'
     }
   },
   methods: {
@@ -11,7 +11,7 @@ export default {
       this.isRed = !this.isRed
     },
     toggleColor() {
-      this.color = this.color === 'зеленый' ? 'синий' : 'зеленый'
+      this.color = this.color === 'green' ? 'blue' : 'green'
     }
   }
 }


### PR DESCRIPTION
## Description of Problem

Проблема на странице с примерами в разделе Attribute Bindings, неправильное название переменных (лишний перевод) в Options API => цвет параграфа не менялся

## Proposed Solution

Ошибка в Options API исправлена
! ошибку в Composition API исправляли - #410