### PR TITLE
fix: variables in /examples/practical/grid

### DIFF
--- a/src/examples/src/grid/App/composition.js
+++ b/src/examples/src/grid/App/composition.js
@@ -7,7 +7,7 @@ export default {
   },
   setup() {
     const searchQuery = ref('')
-    const gridColumns = ['имя', 'сила']
+    const gridColumns = ['name', 'power']
     const gridData = [
       { name: 'Чак Норис', power: Infinity },
       { name: 'Брюс Ли', power: 9000 },

--- a/src/examples/src/grid/App/options.js
+++ b/src/examples/src/grid/App/options.js
@@ -6,7 +6,7 @@ export default {
   },
   data: () => ({
     searchQuery: '',
-    gridColumns: ['имя', 'сила'],
+    gridColumns: ['name', 'power'],
     gridData: [
       { name: 'Чак Норис', power: Infinity },
       { name: 'Брюс ли', power: 9000 },


### PR DESCRIPTION
## Description of Problem

Ошибка в блоке с примерами в разделе Grid with Sort and Filter, лишний перевод не отрисовывал данные в таблице

## Proposed Solution

Исправлена ошибка и в Options API и в Composition API
Таблица и соответственно пример работаю правильно