### PR TITLE
translate: template refs in /extras/render-functions

### DIFF
--- a/src/guide/extras/render-function.md
+++ b/src/guide/extras/render-function.md
@@ -728,7 +728,7 @@ export default {
 </div>
 <div class="options-api">
 
-With the Options API, template refs are created by passing the ref name as a string in the vnode props:
+С Options API ссылки на шаблон создаются путем передачи соответствующего имени ref в виде строки в vnode props:
 
 ```js
 export default {


### PR DESCRIPTION
## Description of Problem

Недопереведен блок template refs в /guide/extras-render-function для Options API

## Proposed Solution

Переведен template refs для Options API