### PR TITLE
Update config.ts

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -670,6 +670,11 @@ export default defineConfigWithTheme<ThemeConfig>({
 
     localeLinks: [
       {
+        link: 'https://vuejs.org',
+        text: 'English',
+        repo: 'https://github.com/vuejs/docs'
+    	},
+      {
         link: 'https://cn.vuejs.org',
         text: '简体中文',
         repo: 'https://github.com/vuejs-translations/docs-zh-cn'


### PR DESCRIPTION
Добавляет возможность переходить обратно по ссылке на английскую версию сайта

## Description of Problem
Если вы перешли по ссылке с английского сайта на русскую версию, снова наведя в шапке на языки перейти назад на английскую версию невозможно, т.к в выпадающем списке нет ссылки на оригинальный сайт

## Proposed Solution
Добавил нужные данные в config.ts, теперь в выпадающем списке появится ссылка на оригинальный сайт

## Additional Information
