### PR TITLE
fix (reactivity-fundamentals.md): correct the translation using the English source

### DIFF
--- a/src/guide/essentials/reactivity-fundamentals.md
+++ b/src/guide/essentials/reactivity-fundamentals.md
@@ -431,7 +431,7 @@ console.log(proxy.nested === raw) // false
 
 ### Ограничения `reactive()` {#limitations-of-reactive}
 
-API `reactive()` имеет два ограничения:
+API `reactive()` имеет несколько ограничений:
 
 1. **Ограниченные типы значений:** работает только для типов объектов (objects, arrays, и [типы коллекций](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects#keyed_collections) такие как `Map` и `Set`). Он не может удерживать [примитивные типы](https://developer.mozilla.org/en-US/docs/Glossary/Primitive) такие как `string`, `number` или `boolean`.
 


### PR DESCRIPTION
## Description of Problem

The number of the limitations is three, not two. The English source uses
> The `reactive()` API has a few limitations:

## Proposed Solution

I suggest using direct translation. Also, specifying a number is less convenient due to the fact that the quantity may change.
> API `reactive()` имеет несколько ограничений:

## Additional Information

—