### PR TITLE
Update v-model.md

### DIFF
--- a/src/guide/components/v-model.md
+++ b/src/guide/components/v-model.md
@@ -68,7 +68,7 @@ const emit = defineEmits(['update:modelValue'])
 
 <template>
   <input
-    :value="props.modelValue"
+    :value="modelValue"
     @input="emit('update:modelValue', $event.target.value)"
   />
 </template>


### PR DESCRIPTION
Unnecessary expression

## Description of Problem
You don't need to use :props.some_ref, you can use just :some_ref

## Proposed Solution
:value="modelValue"