### PR TITLE
Update custom-directives.md

### DIFF
--- a/src/guide/reusability/custom-directives.md
+++ b/src/guide/reusability/custom-directives.md
@@ -142,7 +142,7 @@ const focus = {
 
 export default {
   directives: {
-    // включение v-highlight в шаблоне
+    // включение v-focus в шаблоне
     focus
   }
 }


### PR DESCRIPTION
The author forgot to change directive's name from the previous example. In the previous example the name of directive was "highlight" but in this example it is "focus"

## Description of Problem
the author left directive's name from the previous example
## Proposed Solution
change the name of directive to current name
## Additional Information
