### PR TITLE
Update PreferenceTooltip.vue

### DIFF
--- a/.vitepress/theme/components/PreferenceTooltip.vue
+++ b/.vitepress/theme/components/PreferenceTooltip.vue
@@ -99,7 +99,7 @@ function dismiss() {
   <Transition name="fly-in">
     <div class="preference-tooltip" v-if="show">
       <template v-if="source === 'default'">
-        <p>Дефолтный стиль API теперь Composition API.</p>
+        <p>Теперь по умолчанию используется Composition API.</p>
         <p>
           Некоторые страницы содержат различный контент основанный на выбранном стиле API.
           Используйте переключатель для переключения между стилями API.


### PR DESCRIPTION
Remove unnecessary slang

## Description of Problem
Всплывающее сообщение, которое видит любой пользователь, впервые посетивший сайт, начинается со слова "Дефолтный". Это невольно создаёт ощущение, что проект, зачем-то, очень сильно хочет «казаться модным и молодёжным».

![image](https://github.com/user-attachments/assets/e8d29f3d-ab0e-41a8-815f-29e05e00f1aa)

## Proposed Solution
Vue невероятно шикарен и без такого использования сленга в RU-доках. Предлагается заменить фразу на нейтральное выражение:

![image](https://github.com/user-attachments/assets/234df5b6-9dfe-4777-a5fe-ad993fe35746)


## Additional Information
