### PR TITLE
Translate developers page

### DIFF
--- a/src/developers/[developerSlug].md
+++ b/src/developers/[developerSlug].md
@@ -1,7 +1,7 @@
 ---
 page: true
 footer: false
-title: Vue Developer
+title: Vue разработчик
 ---
 
 <script setup>
@@ -15,7 +15,7 @@ const developer = ref(developersData.find(dev => dev.slug === page.value.params.
 
 onMounted(() => {
   if (developer.value) {
-    document.title = `${developer.value.name} - Vue Developer | Vue.js`
+    document.title = `${developer.value.name} - Vue разработчик | Vue.js`
   }
 })
 </script>

--- a/src/developers/components/DeveloperCard.vue
+++ b/src/developers/components/DeveloperCard.vue
@@ -52,7 +52,7 @@ const trimmedDescription = truncateTextFromArray(description, 220)
 
     <DeveloperCompensations
       v-if="hero && compensations"
-      title="Compensation"
+      title="Оплата"
       :compensations="compensations"
       class="developer-card__section developer-card__compensation"
     />
@@ -60,7 +60,7 @@ const trimmedDescription = truncateTextFromArray(description, 220)
     <DeveloperProficiencies
       v-if="proficiencies"
       :proficiencies="proficiencies"
-      :title="hero ? 'Main proficiencies' : undefined"
+      :title="hero ? 'Основные навыки' : undefined"
       enable-show-all
       class="developer-card__section developer-card__proficiencies"
       @click.stop

--- a/src/developers/components/DeveloperCompensations.vue
+++ b/src/developers/components/DeveloperCompensations.vue
@@ -18,8 +18,8 @@ defineProps<{
         </div>
       </div>
       <div v-if="showDetails" class="developer-compensations__details">
-        <p>No other costs.</p>
-        <p>One month trial period, thereafter, one month notice period.</p>
+        <p>Без дополнительных затрат.</p>
+        <p>Испытательный срок - 1 месяц, далее - уведомление за 1 месяц.</p>
       </div>
     </div>
   </div>

--- a/src/developers/components/DeveloperLanding.vue
+++ b/src/developers/components/DeveloperLanding.vue
@@ -26,8 +26,8 @@ onMounted(() => {
 
 <template>
   <PageShowcaseListLayout
-    spotlightTitle="Spotlight"
-    featuredTitle="Vue.js Certified developers"
+    spotlightTitle="В центре внимания"
+    featuredTitle="Сертифицированные Vue.js разработчики"
   >
     <template #hero>
       <DeveloperHero />
@@ -44,7 +44,7 @@ onMounted(() => {
         target="_blank"
         class="accent-button"
       >
-        Contact {{ partnerConfig.partnerName }} for a tailored fit
+        Свяжитесь с {{ partnerConfig.partnerName }}
       </a>
     </template>
 
@@ -64,7 +64,7 @@ onMounted(() => {
           target="_blank"
           class="accent-button"
         >
-          Contact {{ partnerConfig.partnerName }} for a tailored fit
+          Свяжитесь с {{ partnerConfig.partnerName }} для индивидуального подбора
         </a>
       </div>
     </template>

--- a/src/developers/components/DeveloperPage.vue
+++ b/src/developers/components/DeveloperPage.vue
@@ -30,7 +30,7 @@ const hireUsLink = computed(() => generateUTMUrl(partnerConfig.hireUsButtonUrl, 
     <div class="developer-page__back">
       <a href="./index.html">
         <VTIconChevronLeft class="developer-page__icon" />
-        All Vue.js certified developers
+        Все сертифицированные Vue.js разработчики
       </a>
     </div>
 
@@ -48,7 +48,7 @@ const hireUsLink = computed(() => generateUTMUrl(partnerConfig.hireUsButtonUrl, 
         <div class="developer-page__main-info">
           <h2 v-if="name" class="developer-page__name">{{ name }}</h2>
           <a v-if="hireUsLink" class="accent-button developer-page__main-action" :href="hireUsLink" target="_blank">
-            Get in contact
+            Связаться
           </a>
 
           <p v-if="location" class="developer-page__location">
@@ -64,7 +64,7 @@ const hireUsLink = computed(() => generateUTMUrl(partnerConfig.hireUsButtonUrl, 
         <DeveloperCompensations
           v-if="compensations"
           class="developer-page__text-section"
-          title="Compensation"
+          title="Оплата"
           :compensations="compensations"
           :showDetails="true"
         />
@@ -72,7 +72,7 @@ const hireUsLink = computed(() => generateUTMUrl(partnerConfig.hireUsButtonUrl, 
         <DeveloperProficiencies
           v-if="proficiencies"
           class="developer-page__text-section"
-          title="Proficiencies"
+          title="Профессиональные навыки"
           :proficiencies="proficiencies"
         />
 
@@ -98,14 +98,14 @@ const hireUsLink = computed(() => generateUTMUrl(partnerConfig.hireUsButtonUrl, 
         <DeveloperExperiences
           v-if="experiences"
           class="developer-page__text-section"
-          title="Selected experience"
+          title="Избранный опыт"
           :experiences="experiences"
         />
 
         <DeveloperEducation
           v-if="education"
           class="developer-page__text-section"
-          title="Education"
+          title="Образование"
           :education="education"
         />
       </div>

--- a/src/developers/components/DeveloperPageFooter.vue
+++ b/src/developers/components/DeveloperPageFooter.vue
@@ -45,7 +45,7 @@ const { logo, partnerName } = partnerConfig
     </div>
 
     <a class="partner-footer__contact-button accent-button" :href="hireUsLink" target="_blank">
-      Get in contact
+      Связаться
     </a>
   </footer>
 </template>

--- a/src/developers/components/DeveloperProficiencies.vue
+++ b/src/developers/components/DeveloperProficiencies.vue
@@ -43,7 +43,7 @@ const toggleShowAll = (event: Event) => {
         class="developer-proficiencies__toggle"
         @click.stop="toggleShowAll"
       >
-        {{ showAll ? 'Show less' : 'Show all' }}
+        {{ showAll ? 'Показать меньше' : 'Показать все' }}
       </button>
     </div>
   </div>

--- a/src/developers/index.md
+++ b/src/developers/index.md
@@ -1,7 +1,7 @@
 ---
 page: true
 footer: false
-title: Vue Developers
+title: Vue разработчики
 ---
 
 <script setup>

--- a/src/developers/partnerConfig.js
+++ b/src/developers/partnerConfig.js
@@ -25,29 +25,29 @@ const partnerConfig = {
 
   // Hero Section
   pageHeroBanner: {
-    title: 'Find top Vue.js developers for your team',
-    description1: 'Access certified Vue.js developers available for your next project.',
-    description2: 'Proxify handles the vetting process to ensure top-tier quality and reliability.',
+    title: 'Найдите лучших Vue.js разработчиков для вашей команды',
+    description1: 'Получите доступ к сертифицированным Vue.js разработчикам для вашего следующего проекта.',
+    description2: 'Proxify проводит тщательный отбор специалистов, гарантируя высочайшее качество и надежность.',
     hireButton: {
       url: hireUrl,
-      label: 'Find Vue.js developers now'
+      label: 'Найдите разработчиков Vue.js'
     },
-    footer: "Get matched with a top Vue.js developer in less than 48 hours",
+    footer: 'Найдите лучшего Vue.js разработчика менее чем за 48 часов',
   },
 
   // Hero Section
   pageJoinSection: {
-    title: 'Become a listed developer',
-    description: 'Get a long-term part-time or full-time position at company looking for a Vue.js developer.',
+    title: 'Попасть в список разработчиков',
+    description: 'Получите долгосрочную работу с частичной или полной занятостью в компании, которая ищет Vue.js разработчика.',
     applyButton: {
       url: applyUrl,
-      label: 'Apply to join'
+      label: 'Подать заявку на вступление'
     }
   },
 
   // Footer Configuration
   pageFooter: {
-    text: `This highly vetted developer is brought to you by Vue’s partner:`,
+    text: 'Этот тщательно отобранный разработчик предоставлен партнёром Vue:',
     email: 'vue@proxify.io',
     phone: '+44 20 4614 2667',
     websiteVueLink: vueArticleUrl,
@@ -56,14 +56,14 @@ const partnerConfig = {
 
   // Diagram sections
   profileDiagram: {
-    title: 'Candidate profile',
-    prependText: 'How our developers score in the parameters that correlate best with future success in the role.'
+    title: 'Профиль кандидата',
+    prependText: 'Как наши разработчики оцениваются по параметрам, которые наиболее точно предсказывают успех в данной роли.'
   },
 
   scoreDiagram: {
-    title: 'Engineering excellence score',
-    prependText: 'The practical score range is 0 to 300. This is the distribution of scores for all evaluated Vue.js developers, and here’s where your candidate scored.',
-    appendText: 'Data from 3,661 evaluated Vue.js developers and 38,008 applicants.'
+    title: 'Оценка инженерного мастерства',
+    prependText: 'Шкала оценки варьируется от 0 до 300. На графике показаны распределение баллов всех оценённых Vue.js разработчиков и как оценён ваш кандидат.',
+    appendText: 'Данные по 3 661 оценённому Vue.js разработчику из 38 008 кандидатов.'
   },
 
   // Proficiency Section


### PR DESCRIPTION
## Description of Problem
Closes https://github.com/vuejs-translations/docs-ru/issues/504

## Proposed Solution
Переведены тексты и мета-данные, за исключением файла `/src/developers/developers.json`, для него сделала отдельный PR, т.к. объём немаленький https://github.com/vuejs-translations/docs-ru/issues/503 :)

## Additional Information
В файле [DeveloperLanding.vue](https://github.com/vuejs-translations/docs-ru/blob/main/src/developers/components/DeveloperLanding.vue) есть текст кнопки: `Contact {{ partnerConfig.partnerName }} for a tailored fit`. И дословный перевод слишком растягивает кнопку, поэтому я немного сократила его до `Свяжитесь с {{ partnerConfig.partnerName }}`.
На этой же странице есть такая же кнопка ниже, там она смотрится хорошо с полноценным переводом. 

Похожая ситуация с файлом [partnerConfig.js](https://github.com/vuejs-translations/docs-ru/blob/main/src/developers/partnerConfig.js), тут текст кнопки `Find Vue.js developers now` тоже выглядит слишком растянуто с дословным переводом, поэтому немного сократила - `Найдите разработчиков Vue.js`. 